### PR TITLE
Disambiguate paths with different numbers of variable parts

### DIFF
--- a/src/rhumb.js
+++ b/src/rhumb.js
@@ -77,11 +77,15 @@ function create (){
       peek = node.fixed[part.input] || (node.fixed[part.input] = {})
     }
     else if(part.type == "var"){
-      if(node.var){
-        throw new Error("Ambiguity")
+      if(node.var) {
+        if(node.var.name == part.input) {
+          peek = node.var
+        } else {
+          throw new Error("Ambiguity")
+        }
+      } else {
+        peek = node.var = { name : part.input }
       }
-      peek = (node.var = {})
-      peek.name = part.input
     }
     else if(part.type = "partial"){
       if(node.partial){

--- a/test/test.rhumb.js
+++ b/test/test.rhumb.js
@@ -48,6 +48,20 @@ describe("routing", function(){
       router.match("/wibble/humm/wobble")
       spy.should.have.been.calledOnce
     })
+    it("should match /foo/{bar} and /foo/{bar}/{baz} as different paths", function(){
+      var router = rhumb.create()
+        , one = sinon.spy()
+        , two = sinon.spy()
+
+      router.add("/foo/{bar}", one)
+      router.add("/foo/{bar}/{baz}", two)  
+
+      router.match("/foo/wee")
+      router.match("/foo/wee/waa")
+
+      one.should.have.been.calledOnce.calledWith({bar:"wee"})
+      two.should.have.been.calledOnce.calledWith({bar:"wee", baz:"waa"})
+    })
   })
   describe("matching with partially variable paths", function(){
     it("should match /page-{num} with path /page-four", function(){


### PR DESCRIPTION
Should allow separate routing of paths such as
/foo/{bar}
/foo/{bar}/{baz}
