### PR TITLE
Popper!

### DIFF
--- a/.popper.yml
+++ b/.popper.yml
@@ -1,0 +1,10 @@
+tests: (npm run pretest > /dev/null) && browserify test/test.rhumb.js
+
+watch: 
+  - src
+  - test
+
+browsers:
+  - chrome
+  - firefox
+  - ie11

--- a/package.json
+++ b/package.json
@@ -7,16 +7,17 @@
     "browserify": "^11.1.0",
     "chai": "^3.2.0",
     "mocha": "^2.3.2",
+    "popper": "0.0.20",
     "sinon": "^1.16.1",
     "sinon-chai": "^2.8.0"
   },
   "scripts": {
-    "test": "mocha",
+    "test-node": "mocha",
     "clean": "rm -rf lib",
-    "compile": "mkdir -p lib && browserify src/rhumb.js --standalone rhumb -o lib/rhumb.js",
+    "compile": "npm run clean && mkdir lib && browserify src/rhumb.js --standalone rhumb -o lib/rhumb.js",
     "pretest": "npm run compile",
     "prepublish": "npm run clean && npm run compile && npm test",
-    "test-browser": "npm run pretest && browserify test/test.rhumb.js -o lib/test.rhumb.js && open test/index.html"
+    "test": "popper"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Just run `popper` (or `popper -b`, where `-b` means an empty list of browsers, which overrides the list of browsers in the `.popper.yml`, which basically means, don't spawn any browsers in BrowserStack for this run, which is useful if you are just running locally).

This is what `:1945/dashboard` looks like (note: kept dashboard UI simple, so it just categorises by top-level `describes` - I prefer having a flatter list so I can see more rows):

![image](https://cloud.githubusercontent.com/assets/2184177/9939406/f1e596c8-5d61-11e5-8c08-7a44bd76fc34.png)

This is what the test agents on `:1945` look like:

![image](https://cloud.githubusercontent.com/assets/2184177/9939515/8aace1c2-5d62-11e5-83e0-3223607b567f.png)

This is what `npm test` looks like (i.e. results from Travis):

![image](https://cloud.githubusercontent.com/assets/2184177/9939468/34b512e4-5d62-11e5-84a4-99a440e197db.png)

This is what running the same tests on node via `npm test-node` (i.e. `mocha`) looks like (it;s on the roadmap to have popper pull these results into the same dashboard):

![image](https://cloud.githubusercontent.com/assets/2184177/9939503/7acf4fec-5d62-11e5-89a2-6c95b3a89371.png)
